### PR TITLE
Fix/optimize collision detection

### DIFF
--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionPair.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionPair.kt
@@ -1,15 +1,25 @@
 package org.valkyrienskies.krunch.collision
 
+import org.joml.Vector3d
 import org.joml.Vector3dc
 
 /**
- * A [CollisionPair] describes how to resolve a collision using two points. Both of these points must be pushed apart along normal to resolve the collision.
+ * A [CollisionPair] describes how to resolve a collision using two points.
+ *
+ * Both of these points must be pushed apart along [normalThisSubStep] to resolve the collision.
  */
 class CollisionPair(
-    override var positionInFirstBody: Vector3dc,
-    override var positionInSecondBody: Vector3dc,
-    override var normal: Vector3dc,
-    override var used: Boolean = false,
-    override var normalLambda: Double = 0.0,
-    override var tangentialLambda: Double = 0.0
-) : CollisionPairc
+    override val positionInFirstBody: Vector3dc,
+    override val positionInSecondBody: Vector3dc,
+    override val originalCollisionNormal: Vector3dc
+) : CollisionPairc {
+    /**
+     * Set [skipThisSubStep] to true when its impossible to determine a normal.
+     * (For example, when contact points are exactly on top of each other, the displacement is 0, so no normal exists)
+     */
+    override var skipThisSubStep: Boolean = false
+    override var normalThisSubStep: Vector3d = Vector3d()
+    override var usedThisSubStep: Boolean = false
+    override var normalLambdaThisSubStep: Double = 0.0
+    override var tangentialLambdaThisSubStep: Double = 0.0
+}

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionPairc.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionPairc.kt
@@ -4,12 +4,18 @@ import org.joml.Vector3dc
 
 /**
  * Immutable view of [CollisionPair].
+ *
+ * Note that only [positionInFirstBody], [positionInSecondBody], and [originalCollisionNormal] are immutable.
+ *
+ * The other fields are updated during sub-steps and iterations.
  */
 interface CollisionPairc {
     val positionInFirstBody: Vector3dc
     val positionInSecondBody: Vector3dc
-    val normal: Vector3dc
-    var used: Boolean
-    var normalLambda: Double
-    var tangentialLambda: Double
+    val originalCollisionNormal: Vector3dc
+    val skipThisSubStep: Boolean
+    val normalThisSubStep: Vector3dc
+    val usedThisSubStep: Boolean
+    val normalLambdaThisSubStep: Double
+    val tangentialLambdaThisSubStep: Double
 }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionResult.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionResult.kt
@@ -3,15 +3,4 @@ package org.valkyrienskies.krunch.collision
 /**
  * Stores the collision points between two collision shapes.
  */
-class CollisionResult(private var _collisionPoints: Collection<CollisionPairc>) :
-    CollisionResultc {
-
-    override val colliding: Boolean
-        get() = _collisionPoints.isNotEmpty()
-
-    override val collisionPoints: Collection<CollisionPairc>
-        get() {
-            if (!colliding) throw NotCollidingException("Cannot get collisionPoints because we are not colliding!")
-            return _collisionPoints
-        }
-}
+class CollisionResult(override val collisionPoints: Collection<CollisionPair>) : CollisionResultc

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionResultc.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/CollisionResultc.kt
@@ -4,6 +4,5 @@ package org.valkyrienskies.krunch.collision
  * Immutable view of [CollisionResult].
  */
 interface CollisionResultc {
-    val colliding: Boolean
     val collisionPoints: Collection<CollisionPairc>
 }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/Collider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/Collider.kt
@@ -1,7 +1,7 @@
 package org.valkyrienskies.krunch.collision.colliders
 
 import org.valkyrienskies.krunch.Pose
-import org.valkyrienskies.krunch.collision.CollisionResultc
+import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
 
 /**
@@ -11,5 +11,5 @@ interface Collider<in Body0ShapeType : CollisionShape, in Body1ShapeType : Colli
     fun computeCollisionBetweenShapes(
         body0Shape: Body0ShapeType, body0Transform: Pose, body1Shape: Body1ShapeType,
         body1Transform: Pose
-    ): CollisionResultc?
+    ): CollisionResult?
 }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/Collider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/Collider.kt
@@ -1,5 +1,6 @@
 package org.valkyrienskies.krunch.collision.colliders
 
+import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
@@ -8,8 +9,20 @@ import org.valkyrienskies.krunch.collision.shapes.CollisionShape
  * Computes the collision points between two collision shapes.
  */
 interface Collider<in Body0ShapeType : CollisionShape, in Body1ShapeType : CollisionShape> {
+
+    /**
+     * This computes speculative contacts using [body0Velocity], [body0AngularVelocity], [body1Velocity], [body1AngularVelocity], [dt], and [speculativeThreshold].
+     */
     fun computeCollisionBetweenShapes(
-        body0Shape: Body0ShapeType, body0Transform: Pose, body1Shape: Body1ShapeType,
-        body1Transform: Pose
+        body0Shape: Body0ShapeType,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: Body1ShapeType,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult?
 }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/ColliderResolver.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/ColliderResolver.kt
@@ -1,41 +1,81 @@
 package org.valkyrienskies.krunch.collision.colliders
 
+import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.BoxShape
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
-import org.valkyrienskies.krunch.collision.shapes.CombinedShape
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
 import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
 
 object ColliderResolver : Collider<CollisionShape, CollisionShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: CollisionShape, body0Transform: Pose, body1Shape: CollisionShape, body1Transform: Pose
+        body0Shape: CollisionShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: CollisionShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult? {
         return when {
-            (body0Shape is CombinedShape) -> {
-                CombinedShapeCollider.computeCollisionBetweenShapes(
-                    body0Shape, body0Transform, body1Shape, body1Transform
-                )
-            }
             (body0Shape is SphereShape) && (body1Shape is SphereShape) -> {
                 SphereSphereCollider.computeCollisionBetweenShapes(
-                    body0Shape, body0Transform, body1Shape, body1Transform
+                    body0Shape,
+                    body0Transform,
+                    body0Velocity,
+                    body0AngularVelocity,
+                    body1Shape,
+                    body1Transform,
+                    body1Velocity,
+                    body1AngularVelocity,
+                    dt,
+                    speculativeThreshold
                 )
             }
             (body0Shape is SphereShape) && (body1Shape is TSDFVoxelShape) -> {
                 SphereTSDFVoxelCollider.computeCollisionBetweenShapes(
-                    body0Shape, body0Transform, body1Shape, body1Transform
+                    body0Shape,
+                    body0Transform,
+                    body0Velocity,
+                    body0AngularVelocity,
+                    body1Shape,
+                    body1Transform,
+                    body1Velocity,
+                    body1AngularVelocity,
+                    dt,
+                    speculativeThreshold
                 )
             }
             (body0Shape is SphereShape) && (body1Shape is BoxShape) -> {
                 SphereBoxCollider.computeCollisionBetweenShapes(
-                    body0Shape, body0Transform, body1Shape, body1Transform
+                    body0Shape,
+                    body0Transform,
+                    body0Velocity,
+                    body0AngularVelocity,
+                    body1Shape,
+                    body1Transform,
+                    body1Velocity,
+                    body1AngularVelocity,
+                    dt,
+                    speculativeThreshold
                 )
             }
             (body0Shape is TSDFVoxelShape) && (body1Shape is TSDFVoxelShape) -> {
                 TSDFVoxelTSDFVoxelCollider.computeCollisionBetweenShapes(
-                    body0Shape, body0Transform, body1Shape, body1Transform
+                    body0Shape,
+                    body0Transform,
+                    body0Velocity,
+                    body0AngularVelocity,
+                    body1Shape,
+                    body1Transform,
+                    body1Velocity,
+                    body1AngularVelocity,
+                    dt,
+                    speculativeThreshold
                 )
             }
             else -> {

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/ColliderResolver.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/ColliderResolver.kt
@@ -1,7 +1,7 @@
 package org.valkyrienskies.krunch.collision.colliders
 
 import org.valkyrienskies.krunch.Pose
-import org.valkyrienskies.krunch.collision.CollisionResultc
+import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.BoxShape
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
 import org.valkyrienskies.krunch.collision.shapes.CombinedShape
@@ -11,7 +11,7 @@ import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
 object ColliderResolver : Collider<CollisionShape, CollisionShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: CollisionShape, body0Transform: Pose, body1Shape: CollisionShape, body1Transform: Pose
-    ): CollisionResultc? {
+    ): CollisionResult? {
         return when {
             (body0Shape is CombinedShape) -> {
                 CombinedShapeCollider.computeCollisionBetweenShapes(

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/CombinedShapeCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/CombinedShapeCollider.kt
@@ -1,17 +1,26 @@
 package org.valkyrienskies.krunch.collision.colliders
 
-import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
-import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
 import org.valkyrienskies.krunch.collision.shapes.CombinedShape
 
 object CombinedShapeCollider : Collider<CombinedShape, CollisionShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: CombinedShape, body0Transform: Pose, body1Shape: CollisionShape, body1Transform: Pose
+        body0Shape: CombinedShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: CollisionShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult? {
+        return null
+        /*
         var minDepth = Double.MAX_VALUE
         var minCollisionPair: CollisionPair? = null
         for (pair in body0Shape.collisionShapes) {
@@ -47,5 +56,7 @@ object CombinedShapeCollider : Collider<CombinedShape, CollisionShape> {
         } else {
             CollisionResult(listOf(minCollisionPair!!))
         }
+
+         */
     }
 }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/CombinedShapeCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/CombinedShapeCollider.kt
@@ -4,18 +4,16 @@ import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
-import org.valkyrienskies.krunch.collision.CollisionPairc
 import org.valkyrienskies.krunch.collision.CollisionResult
-import org.valkyrienskies.krunch.collision.CollisionResultc
 import org.valkyrienskies.krunch.collision.shapes.CollisionShape
 import org.valkyrienskies.krunch.collision.shapes.CombinedShape
 
 object CombinedShapeCollider : Collider<CombinedShape, CollisionShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: CombinedShape, body0Transform: Pose, body1Shape: CollisionShape, body1Transform: Pose
-    ): CollisionResultc? {
+    ): CollisionResult? {
         var minDepth = Double.MAX_VALUE
-        var minCollisionPair: CollisionPairc? = null
+        var minCollisionPair: CollisionPair? = null
         for (pair in body0Shape.collisionShapes) {
             val shape = pair.first
             val pose = pair.second
@@ -33,13 +31,13 @@ object CombinedShapeCollider : Collider<CombinedShape, CollisionShape> {
                 )
                 val difference = Vector3d(body1CollisionPointGlobal).sub(body0CollisionPointGlobal)
 
-                val depth = it.normal.dot(difference)
+                val depth = it.originalCollisionNormal.dot(difference)
 
                 if (depth < minDepth) {
                     minDepth = depth
                     minCollisionPair = CollisionPair(
                         body0Transform.invTransform(Vector3d(body0CollisionPointGlobal)), it.positionInSecondBody,
-                        it.normal
+                        it.originalCollisionNormal
                     )
                 }
             }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereBoxCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereBoxCollider.kt
@@ -5,7 +5,6 @@ import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
-import org.valkyrienskies.krunch.collision.CollisionResultc
 import org.valkyrienskies.krunch.collision.shapes.BoxShape
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
 import kotlin.math.abs
@@ -15,7 +14,7 @@ import kotlin.math.min
 object SphereBoxCollider : Collider<SphereShape, BoxShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: SphereShape, body0Transform: Pose, body1Shape: BoxShape, body1Transform: Pose
-    ): CollisionResultc? {
+    ): CollisionResult? {
         val spherePosRelativeToBox: Vector3dc = body1Transform.invTransform(Vector3d(body0Transform.p))
 
         val closestPointRelativeToBoxInBody1Coordinates = Vector3d(

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereBoxCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereBoxCollider.kt
@@ -7,13 +7,23 @@ import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.BoxShape
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
+import org.valkyrienskies.krunch.computeRelativeVelocity
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
 object SphereBoxCollider : Collider<SphereShape, BoxShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: SphereShape, body0Transform: Pose, body1Shape: BoxShape, body1Transform: Pose
+        body0Shape: SphereShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: BoxShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult? {
         val spherePosRelativeToBox: Vector3dc = body1Transform.invTransform(Vector3d(body0Transform.p))
 
@@ -30,16 +40,27 @@ object SphereBoxCollider : Collider<SphereShape, BoxShape> {
 
         val difference =
             body1Transform.transform(Vector3d(closestPointRelativeToBoxInBody1Coordinates)).sub(body0Transform.p)
-        if ((difference.lengthSquared() < body0Shape.radius * body0Shape.radius) &&
-            difference.lengthSquared() > 1e-12
-        ) {
-            val normal = Vector3d(difference).normalize()
-            val deepestSpherePoint = Vector3d(body0Transform.p)
-            if (!isSphereCenterWithinBox) {
-                deepestSpherePoint.fma(body0Shape.radius, normal)
-            } else {
-                deepestSpherePoint.fma(-body0Shape.radius, normal)
-            }
+
+        if (difference.lengthSquared() < 1e-12) return null
+
+        val normal = Vector3d(difference).normalize()
+
+        val deepestSpherePoint = Vector3d(body0Transform.p)
+        if (!isSphereCenterWithinBox) {
+            deepestSpherePoint.fma(body0Shape.radius, normal)
+        } else {
+            deepestSpherePoint.fma(-body0Shape.radius, normal)
+        }
+
+        val relativeVelocity = computeRelativeVelocity(
+            normal, body0Transform.invTransform(Vector3d(deepestSpherePoint)),
+            closestPointRelativeToBoxInBody1Coordinates, body0Velocity, body0AngularVelocity, body1Velocity,
+            body1AngularVelocity, dt
+        )
+
+
+        if (difference.length() + relativeVelocity - speculativeThreshold < body0Shape.radius) {
+
             return CollisionResult(
                 listOf(
                     CollisionPair(

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereSphereCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereSphereCollider.kt
@@ -1,26 +1,47 @@
 package org.valkyrienskies.krunch.collision.colliders
 
 import org.joml.Vector3d
+import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
+import org.valkyrienskies.krunch.computeRelativeVelocity
+import kotlin.math.sqrt
 
 object SphereSphereCollider : Collider<SphereShape, SphereShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: SphereShape, body0Transform: Pose, body1Shape: SphereShape, body1Transform: Pose
+        body0Shape: SphereShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: SphereShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult? {
         val difference = Vector3d(body1Transform.p).sub(body0Transform.p)
         val differenceLengthSq = difference.lengthSquared()
-        if ((differenceLengthSq > 1e-12) &&
-            (differenceLengthSq < (body0Shape.radius + body1Shape.radius) * (body0Shape.radius + body1Shape.radius))
-        ) {
+        if (differenceLengthSq > 1e-12) {
             val normal = Vector3d(difference).normalize()
             val body0DeepestPoint =
                 body0Transform.invTransform(Vector3d(body0Transform.p).fma(body0Shape.radius, normal))
             val body1DeepestPoint =
                 body1Transform.invTransform(Vector3d(body1Transform.p).fma(-body1Shape.radius, normal))
-            return CollisionResult(listOf(CollisionPair(body0DeepestPoint, body1DeepestPoint, normal)))
+
+            val relativeVelocity = computeRelativeVelocity(
+                normal, body0DeepestPoint, body1DeepestPoint, body0Velocity, body0AngularVelocity, body1Velocity,
+                body1AngularVelocity, dt
+            )
+
+            if ((body0Shape.radius + body1Shape.radius) > sqrt(
+                    differenceLengthSq
+                ) + relativeVelocity - speculativeThreshold
+            ) {
+                return CollisionResult(listOf(CollisionPair(body0DeepestPoint, body1DeepestPoint, normal)))
+            }
         }
         return null
     }

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereSphereCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereSphereCollider.kt
@@ -4,13 +4,12 @@ import org.joml.Vector3d
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
-import org.valkyrienskies.krunch.collision.CollisionResultc
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
 
 object SphereSphereCollider : Collider<SphereShape, SphereShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: SphereShape, body0Transform: Pose, body1Shape: SphereShape, body1Transform: Pose
-    ): CollisionResultc? {
+    ): CollisionResult? {
         val difference = Vector3d(body1Transform.p).sub(body0Transform.p)
         val differenceLengthSq = difference.lengthSquared()
         if ((differenceLengthSq > 1e-12) &&

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereTSDFVoxelCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereTSDFVoxelCollider.kt
@@ -10,7 +10,16 @@ import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
 
 object SphereTSDFVoxelCollider : Collider<SphereShape, TSDFVoxelShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: SphereShape, body0Transform: Pose, body1Shape: TSDFVoxelShape, body1Transform: Pose
+        body0Shape: SphereShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: TSDFVoxelShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult? {
         val spherePosInBody1Coordinates: Vector3dc = body1Transform.invTransform(Vector3d(body0Transform.p))
 

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereTSDFVoxelCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/SphereTSDFVoxelCollider.kt
@@ -5,14 +5,13 @@ import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
-import org.valkyrienskies.krunch.collision.CollisionResultc
 import org.valkyrienskies.krunch.collision.shapes.SphereShape
 import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
 
 object SphereTSDFVoxelCollider : Collider<SphereShape, TSDFVoxelShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: SphereShape, body0Transform: Pose, body1Shape: TSDFVoxelShape, body1Transform: Pose
-    ): CollisionResultc? {
+    ): CollisionResult? {
         val spherePosInBody1Coordinates: Vector3dc = body1Transform.invTransform(Vector3d(body0Transform.p))
 
         val closestSurfacePointOutput = Vector3d()

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/TSDFVoxelTSDFVoxelCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/TSDFVoxelTSDFVoxelCollider.kt
@@ -6,17 +6,15 @@ import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
-import org.valkyrienskies.krunch.collision.CollisionPairc
 import org.valkyrienskies.krunch.collision.CollisionResult
-import org.valkyrienskies.krunch.collision.CollisionResultc
 import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
 import kotlin.math.abs
 
 object TSDFVoxelTSDFVoxelCollider : Collider<TSDFVoxelShape, TSDFVoxelShape> {
     override fun computeCollisionBetweenShapes(
         body0Shape: TSDFVoxelShape, body0Transform: Pose, body1Shape: TSDFVoxelShape, body1Transform: Pose
-    ): CollisionResultc {
-        val collisionPairs = ArrayList<CollisionPairc>()
+    ): CollisionResult {
+        val collisionPairs = ArrayList<CollisionPair>()
 
         val body0VoxelSpaceToLocalCoordinates =
             Matrix4d().scale(body0Shape.scalingFactor).translate(body0Shape.voxelOffset)

--- a/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/TSDFVoxelTSDFVoxelCollider.kt
+++ b/src/main/kotlin/org/valkyrienskies/krunch/collision/colliders/TSDFVoxelTSDFVoxelCollider.kt
@@ -8,11 +8,21 @@ import org.valkyrienskies.krunch.Pose
 import org.valkyrienskies.krunch.collision.CollisionPair
 import org.valkyrienskies.krunch.collision.CollisionResult
 import org.valkyrienskies.krunch.collision.shapes.TSDFVoxelShape
+import org.valkyrienskies.krunch.computeRelativeVelocity
 import kotlin.math.abs
 
 object TSDFVoxelTSDFVoxelCollider : Collider<TSDFVoxelShape, TSDFVoxelShape> {
     override fun computeCollisionBetweenShapes(
-        body0Shape: TSDFVoxelShape, body0Transform: Pose, body1Shape: TSDFVoxelShape, body1Transform: Pose
+        body0Shape: TSDFVoxelShape,
+        body0Transform: Pose,
+        body0Velocity: Vector3dc,
+        body0AngularVelocity: Vector3dc,
+        body1Shape: TSDFVoxelShape,
+        body1Transform: Pose,
+        body1Velocity: Vector3dc,
+        body1AngularVelocity: Vector3dc,
+        dt: Double,
+        speculativeThreshold: Double
     ): CollisionResult {
         val collisionPairs = ArrayList<CollisionPair>()
 
@@ -62,49 +72,55 @@ object TSDFVoxelTSDFVoxelCollider : Collider<TSDFVoxelShape, TSDFVoxelShape> {
                 if (wasClosestSurfacePointFound) {
                     val distanceToClosestSurfacePoint = pointPosInBodyVoxelSpace0.distance(closestSurfacePointOutput)
 
-                    if (distanceToClosestSurfacePoint < pointSphereRadius) {
-                        val collisionNormalOutput = Vector3d(pointPosInBodyVoxelSpace0).sub(closestSurfacePointOutput)
+                    val collisionNormalOutput = Vector3d(pointPosInBodyVoxelSpace0).sub(closestSurfacePointOutput)
 
-                        if (collisionNormalOutput.lengthSquared() < 1e-12) {
-                            // Avoid numerical instability
-                            return@forEachCorner
-                        }
+                    if (collisionNormalOutput.lengthSquared() < 1e-12) {
+                        // Avoid numerical instability
+                        return@forEachCorner
+                    }
 
-                        if (body0Shape.layeredTSDF.getVoxel(
-                                pointPosInBodyVoxelSpace0.x(), pointPosInBodyVoxelSpace0.y(),
-                                pointPosInBodyVoxelSpace0.z()
-                            )
-                        ) {
-                            collisionNormalOutput.mul(-1.0)
-                        }
-                        collisionNormalOutput.normalize()
+                    if (body0Shape.layeredTSDF.getVoxel(
+                            pointPosInBodyVoxelSpace0.x(), pointPosInBodyVoxelSpace0.y(),
+                            pointPosInBodyVoxelSpace0.z()
+                        )
+                    ) {
+                        collisionNormalOutput.mul(-1.0)
+                    }
+                    collisionNormalOutput.normalize()
 
-                        val body1CollisionPointInBody0Coordinates =
-                            body0VoxelSpaceToLocalCoordinates.transformPosition(
-                                Vector3d(pointPosInBodyVoxelSpace0).fma(-pointSphereRadius, collisionNormalOutput)
-                            )
-
-                        val body0CollisionPointInBody0Coordinates =
-                            body0VoxelSpaceToLocalCoordinates.transformPosition(Vector3d(closestSurfacePointOutput))
-
-                        val normalInGlobalCoordinates = body0Transform.rotate(Vector3d(collisionNormalOutput))
-
-                        // If body0Shape has negative scaling, then flip the normal
-                        if (body0Shape.scalingFactor < 0) {
-                            normalInGlobalCoordinates.mul(-1.0)
-                        }
-
-                        val body1CollisionPointInBody1Coordinates = body1Transform.invTransform(
-                            body0Transform.transform(
-                                Vector3d(body1CollisionPointInBody0Coordinates)
-                            )
+                    val body1CollisionPointInBody0Coordinates =
+                        body0VoxelSpaceToLocalCoordinates.transformPosition(
+                            Vector3d(pointPosInBodyVoxelSpace0).fma(-pointSphereRadius, collisionNormalOutput)
                         )
 
-                        val collisionPair = CollisionPair(
-                            body0CollisionPointInBody0Coordinates, body1CollisionPointInBody1Coordinates,
-                            normalInGlobalCoordinates
-                        )
+                    val body0CollisionPointInBody0Coordinates =
+                        body0VoxelSpaceToLocalCoordinates.transformPosition(Vector3d(closestSurfacePointOutput))
 
+                    val normalInGlobalCoordinates = body0Transform.rotate(Vector3d(collisionNormalOutput))
+
+                    // If body0Shape has negative scaling, then flip the normal
+                    if (body0Shape.scalingFactor < 0) {
+                        normalInGlobalCoordinates.mul(-1.0)
+                    }
+
+                    val body1CollisionPointInBody1Coordinates = body1Transform.invTransform(
+                        body0Transform.transform(
+                            Vector3d(body1CollisionPointInBody0Coordinates)
+                        )
+                    )
+
+                    val collisionPair = CollisionPair(
+                        body0CollisionPointInBody0Coordinates, body1CollisionPointInBody1Coordinates,
+                        normalInGlobalCoordinates
+                    )
+
+                    val relativeVelocity = computeRelativeVelocity(
+                        normalInGlobalCoordinates, body0CollisionPointInBody0Coordinates,
+                        body1CollisionPointInBody1Coordinates, body0Velocity, body0AngularVelocity, body1Velocity,
+                        body1AngularVelocity, dt
+                    )
+
+                    if (distanceToClosestSurfacePoint + relativeVelocity - speculativeThreshold < pointSphereRadius) {
                         collisionPairs.add(collisionPair)
                     }
                 }


### PR DESCRIPTION
Only run collision detection once per time step instead of per sub step.

Also add speculative contacts to make the collision stable.